### PR TITLE
Mistyped or forgetton mistake in Readme fixed realting to LICENSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 
 ## 📰 License
 
-> The **[twrm.io](https://twrm.io)** project is released under the [MIT license](LICENSE.md). <br> Developed &amp; maintained By Vasanth Srivatsa. Copyright 2022 © Vasanth Developer.
+> The **[twrm.io](https://twrm.io)** project is released under the [GNU General Public License](LICENSE.md). <br> Developed &amp; maintained By Vasanth Srivatsa. Copyright 2022 © Vasanth Developer.
 
 <hr>
 


### PR DESCRIPTION
I updated Readme.md from MIT license to GNU license , because in project both (readme.md and LICENSE ) were contradicting , as in Readme.md , it was written that project is under MIT license while license was of GNU , so I updated data in Readme.md